### PR TITLE
Initialize textlink contextmenu only if EventTarget is content-area context menu.

### DIFF
--- a/content/textlink/globalOverlay.js
+++ b/content/textlink/globalOverlay.js
@@ -74,7 +74,7 @@ var TextLinkService = {
 				if (aEvent.currentTarget == this.tooltip) {
 					this.buildTooltip(aEvent);
 				}
-				else {
+				else if (aEvent.target == this.contextMenu) {
 					this.initContextMenu();
 				}
 				return;


### PR DESCRIPTION
This commit changes to initialize textlink context menu only if event.target is menupopup#contentAreaContextMenu.
So it need not to initialize every time firing "popupshowing" event from descendants of menupopup#contentAreaContextMenu.
