### PR TITLE
Forbid "dblclick" handling, if mouse was moved or HTML link was focused

### DIFF
--- a/content/textlink/globalOverlay.js
+++ b/content/textlink/globalOverlay.js
@@ -58,9 +58,9 @@ var TextLinkService = {
 	},
 	_bundle : null,
  
-  	forbidDblclick: false,
- 	mousedownPosition: null,
- 	forbidDblclickTolerance: 24,
+	forbidDblclick: false,
+	mousedownPosition: null,
+	forbidDblclickTolerance: 24,
  
 	handleEvent : function(aEvent) 
 	{


### PR DESCRIPTION
Should fix #11 and #14

Main idea: remember "double mousedown" position and compare it with "double mouseup" position.

Additionally removed useless spaces at end of lines. This because of my favorite hotkey, sorry. :)
